### PR TITLE
add dark theme support

### DIFF
--- a/bin/copy-themes.sh
+++ b/bin/copy-themes.sh
@@ -1,5 +1,6 @@
 themes=(
 	casper
+	casper-dark
 	attila
 	london
 	massively

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "private": true,
   "version": "2.27.0",
   "dependencies": {
-    "casper": "github:tryghost/Casper#2.10.6",
+    "casper": "github:tryghost/Casper",
+    "casper-dark": "github:dlford/Casper-Dark",
     "ghost": "2.27.0",
     "ghost-storage-adapter-s3": "^2.8.0",
     "ghost-storage-cloudinary": "^1.1.4",


### PR DESCRIPTION
My eyes were burning, and this - https://github.com/dlford/Casper-Dark - seemed to be a good, actively maintained casper "fork" that added dark support.