### PR TITLE
Allow deploys from forked repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The latest release of Ghost is now supported! Changes include:
 - The app is configured to use `Cloudinary File Storage` by default.
 - Dark Mode on `casper` theme! Please make sure to activate your system's dark-mode first.
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/snathjr/ghost-on-heroku)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
 ### step-by-step tutorial
 


### PR DESCRIPTION
You actually don't need to specify the template URL in your heroku button, as seen here: https://devcenter.heroku.com/articles/heroku-button#adding-the-heroku-button

Removing this allows people to fork this repo and deploy from _their_ repositories without changing the button.