### PR TITLE
Fix Casper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1294,8 +1294,8 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "casper": {
-      "version": "github:tryghost/Casper#17ba4add5cadfe255075ea1addc5dce8dce96993",
-      "from": "github:tryghost/Casper"
+      "version": "github:tryghost/Casper#98543dd0687bc2ef31cee09275c268c717a5b1ff",
+      "from": "github:tryghost/Casper#3.0.4"
     },
     "ccount": {
       "version": "1.0.4",
@@ -4979,6 +4979,10 @@
         "yallist": "^2.1.2"
       }
     },
+    "lyra": {
+      "version": "github:tryghost/lyra#d85b1e35ef76c2bdfae2a2f3bb82c134999c288a",
+      "from": "github:tryghost/lyra"
+    },
     "mailcomposer": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-0.2.12.tgz",
@@ -5989,9 +5993,9 @@
       "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
     },
     "npm": {
-      "version": "6.13.4",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.13.4.tgz",
-      "integrity": "sha512-vTcUL4SCg3AzwInWTbqg1OIaOXlzKSS8Mb8kc5avwrJpcvevDA5J9BhYSuei+fNs3pwOp4lzA5x2FVDXACvoXA==",
+      "version": "6.13.6",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.13.6.tgz",
+      "integrity": "sha512-NomC08kv7HIl1FOyLOe9Hp89kYsOsvx52huVIJ7i8hFW8Xp65lDwe/8wTIrh9q9SaQhA8hTrfXPh3BEL3TmMpw==",
       "requires": {
         "JSONStream": "^1.3.5",
         "abbrev": "~1.1.1",
@@ -6078,7 +6082,7 @@
         "once": "~1.4.0",
         "opener": "^1.5.1",
         "osenv": "^0.1.5",
-        "pacote": "^9.5.11",
+        "pacote": "^9.5.12",
         "path-is-inside": "~1.0.2",
         "promise-inflight": "~1.0.1",
         "qrcode-terminal": "^0.12.0",
@@ -8072,7 +8076,7 @@
           }
         },
         "pacote": {
-          "version": "9.5.11",
+          "version": "9.5.12",
           "bundled": true,
           "requires": {
             "bluebird": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "attila": "github:zutrinken/attila#1.13.0",
     "bleak": "github:zutrinken/bleak#1.4.0",
-    "casper": "github:tryghost/Casper",
+    "casper": "github:tryghost/Casper#3.0.4",
     "ghost": "^3.2.0",
     "ghost-storage-adapter-s3": "^2.8.0",
     "ghost-storage-cloudinary": "^2.0.2",


### PR DESCRIPTION
I noticed that Casper broke when using the default version.
For example, [it isn't showing the navigation bar](https://i.imgur.com/1YBrSZp.jpg), and when you scroll down the article, the [title breaks.](https://i.imgur.com/aJEqZ4q.png)

I had to backtest this with Casper 3.0.6, 3.0.5., and then 3.0.4, and 3.0.4 was the latest version that didn't break either of these:
- https://i.imgur.com/XHaFylX.jpg
- https://i.imgur.com/hTTC0ws.png

So I fixed the version to 3.0.4 and updated the package-lock.json accordingly.

P.S. @SNathJr this is why I keep saying you _need_ to lock the theme versions, because the ghost authors keep breaking them :/