### PR TITLE
fix: use MAILGUN_SMTP_SERVER as the mail host

### DIFF
--- a/bin/create-config
+++ b/bin/create-config
@@ -77,6 +77,7 @@ function createConfig() {
       transport: 'SMTP',
       options: {
         service: 'Mailgun',
+        host: process.env.MAILGUN_SMTP_SERVER,
         auth: {
           user: process.env.MAILGUN_SMTP_LOGIN,
           pass: process.env.MAILGUN_SMTP_PASSWORD


### PR DESCRIPTION
When using Mailgun's European servers the SMTP host needs to be set to `smtp.eu.mailgun.org` vs. `smtp.mailgun.org`. Previously the `MAILGUN_SMTP_SERVER` env var provided by the Mailgun addon was not respected so you'd get 535 SMTP auth errors.